### PR TITLE
Always define options.storage

### DIFF
--- a/src/appservice/Appservice.ts
+++ b/src/appservice/Appservice.ts
@@ -169,6 +169,7 @@ export class Appservice extends EventEmitter {
 
         this.registration = options.registration;
         this.storage = options.storage || new MemoryStorageProvider();
+        options.storage = this.storage;
 
         this.app.use(express.json());
         this.app.use(morgan("combined"));


### PR DESCRIPTION
When intents are created, they are passed the `Appservice`s options, which may not have defined the storage key. This ensures that the storage key is always defined.