### PR TITLE
add tsconfig.json to files in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,8 @@
   "files": [
     "src/*",
     "lib/*",
-    "scripts/*"
+    "scripts/*",
+    "tsconfig.json"
   ],
   "devDependencies": {
     "@types/expect": "^1.20.4",


### PR DESCRIPTION
Otherwise, if there is no `lib` folder after `npm install`, it doesn't know how to build and thus fails