### PR TITLE
Drop bluebird

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,6 @@
   ],
   "dependencies": {
     "@types/express": "^4.17.2",
-    "bluebird": "^3.7.1",
     "chalk": "^3.0.0",
     "express": "^4.17.1",
     "glob-to-regexp": "^0.4.1",

--- a/src/MatrixClient.ts
+++ b/src/MatrixClient.ts
@@ -442,11 +442,11 @@ export class MatrixClient extends EventEmitter {
                 return;
             }
 
-            const response = await this.doSync(token);
-            token = response["next_batch"];
-            this.storage.setSyncToken(token);
-            LogService.info("MatrixClientLite", "Received sync. Next token: " + token);
             try {
+                const response = await this.doSync(token);
+                token = response["next_batch"];
+                this.storage.setSyncToken(token);
+                LogService.info("MatrixClientLite", "Received sync. Next token: " + token);
                 await this.processSync(response);
             } catch (e) {
                 LogService.error("MatrixClientLite", e);

--- a/yarn.lock
+++ b/yarn.lock
@@ -543,7 +543,7 @@ better-docs@^1.4.6:
     vue-docgen-api "^3.22.0"
     vue2-ace-editor "^0.0.13"
 
-bluebird@^3.5.0, bluebird@^3.5.4, bluebird@^3.7.1:
+bluebird@^3.5.0, bluebird@^3.5.4:
   version "3.7.1"
   resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.7.1.tgz#df70e302b471d7473489acf26a93d63b53f874de"
   integrity sha512-DdmyoGCleJnkbp3nkbxTLJ18rjDsE4yCggEwKNXkeV123sPNfOCYeDoeuOY+F2FrSjO1YXcTU+dsy96KMy+gcg==


### PR DESCRIPTION
Fixes #60 

This feels too good to be true, but I've removed the one usage of Bluebird and dropped the package from the dependency list. The tests still seem to pass, so I don't know if there is something special about `Bluebird.method` that this doesn't cover.