### PR TITLE
only set a body and content-type if one is, well, present

### DIFF
--- a/src/MatrixClient.ts
+++ b/src/MatrixClient.ts
@@ -1271,12 +1271,14 @@ export class MatrixClient extends EventEmitter {
             headers: headers,
         };
 
-        if (Buffer.isBuffer(body)) {
-            params.headers["Content-Type"] = contentType;
-            params.body = body;
-        } else {
-            params.headers["Content-Type"] = "application/json";
-            params.body = JSON.stringify(body);
+        if (body) {
+            if (Buffer.isBuffer(body)) {
+                params.headers["Content-Type"] = contentType;
+                params.body = body;
+            } else {
+                params.headers["Content-Type"] = "application/json";
+                params.body = JSON.stringify(body);
+            }
         }
 
         return new Promise((resolve, reject) => {


### PR DESCRIPTION
Some server implementations are picky about the content-type being application/json and the body being `null` *coughs in express*, and when performing GET requests or thelike there shouldn't be a body there to begin with anyways